### PR TITLE
Fix book descript image issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 21.6b0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python3.8

--- a/scraper/books.py
+++ b/scraper/books.py
@@ -74,13 +74,25 @@ def get_author_id(soup):
     return author_url.split("/")[-1]
 
 
+# costarica solution to crashing due to description #3
 def get_description(soup):
-    return soup.find("div", {"id": "description"}).findAll("span")[-1].text
+    if soup.find("div", {"id": "description"}) is None:
+        return "No description found"
+    else:
+        return soup.find("div", {"id": "description"}).findAll("span")[-1].text
 
 
 def get_id(book_id):
     pattern = re.compile("([^.-]+)")
     return pattern.search(book_id).group()
+
+
+# costarica solution to crashing cover image #4
+def get_book_image(soup):
+    if soup.find("img", {"id": "coverImage"}) is None:
+        return "No image found"
+    else:
+        return soup.find("img", {"id": "coverImage"}).attrs.get("src")
 
 
 def scrape_book(book_id: str, args: Namespace):
@@ -94,7 +106,9 @@ def scrape_book(book_id: str, args: Namespace):
         "book_title": " ".join(soup.find("h1", {"id": "bookTitle"}).text.split()),
         "book_description": get_description(soup),
         "book_url": url,
-        "book_image": soup.find("img", {"id": "coverImage"}).attrs.get("src"),
+        "book_image": get_book_image(
+            soup
+        ),  # costarica solution to crashing cover image #4
         "book_series": get_series_name(soup),
         "book_series_uri": get_series_uri(soup),
         "year_first_published": get_year_first_published(soup),


### PR DESCRIPTION
Hi, this is my first pull request. I'm glad to take any advice on how to redo it. I'm sending because I think this update to goodreads-user-scraper is going to be pretty helpful.

## Changes

Both changes affect scraper/books.py.

1. addressed: [Crashes due to error from not finding id="description" read shelf #3](https://github.com/YashTotale/goodreads-user-scraper/issues/3) 

    This prevents the application from crashing when certain books do not have descriptions or at least is there is no `<div id="description"` tag in the html of the book page. So this fix is to just check if the `soup.find("div, {"id": "description"})` is None. If it is none then return "No description found" for the json file.
    
    - The code fixed is shown in comment of reported issue.

2. addressed:  [Crashing when no cover image is found in book #4](https://github.com/YashTotale/goodreads-user-scraper/issues/4) 

    Again, not sure its a fix but certainly prevents crashing of the test script when there is no cover image in the book website.

    Added to book.py :
    - lines 91-95 get_book_image method
    - line 109 call get_book_image method

