### PR TITLE
Make test script robust with venv and python3 fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Ensure that your profile is viewable by anyone:
 4. Run the [test script](/scripts/test.sh)
 
    ```shell
-   sh scripts/test.sh
+   bash scripts/test.sh
    ```
 
 ## Publishing

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,19 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-python -m scraper --user_id 54739262 --output_dir goodreads-data
+cd "$(dirname "$0")/.."
+
+if [ -f .venv/bin/activate ]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+fi
+
+PYTHON="${PYTHON:-python3}"
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  echo "Error: $PYTHON not found."
+  echo "Run scripts/install.sh first."
+  exit 1
+fi
+
+"$PYTHON" -m scraper --user_id 54739262 --output_dir goodreads-data


### PR DESCRIPTION
## Summary
- `scripts/test.sh` previously called bare `python`, which fails on systems where only `python3` is on PATH (e.g., Homebrew Python), implicitly requiring a pre-activated venv.
- Updated it to mirror `install.sh` (commit 9cef3fc): `set -euo pipefail`, `cd` to repo root, source `.venv/bin/activate` if present, fall back to `${PYTHON:-python3}`, and error clearly if no interpreter is available.

## Test plan
- [x] `bash scripts/test.sh` no longer errors with `python: command not found` and successfully invokes the scraper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)