### PR TITLE
Add --version flag and polish CLI help and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 - [Arguments](#arguments)
   - [`--user_id`](#--user_id)
   - [`--output_dir`](#--output_dir)
+  - [`--cookie`](#--cookie)
+  - [`--cookie_file`](#--cookie_file)
   - [`--skip_user_info`](#--skip_user_info)
   - [`--skip_shelves`](#--skip_shelves)
   - [`--skip_authors`](#--skip_authors)
-  - [`--cookie`](#--cookie)
-  - [`--cookie_file`](#--cookie_file)
 - [Authentication](#authentication)
   - [Getting your session cookie](#getting-your-session-cookie)
   - [Passing the cookie](#passing-the-cookie)
@@ -35,38 +35,24 @@
 
 ## Usage
 
+Use [pipx](https://pipx.pypa.io/) or [uv](https://docs.astral.sh/uv/) — both install the CLI from PyPI.
+
 ### Install once, then run
 
 Best for repeat use. Installs the CLI into an isolated environment and adds the `goodreads-user-scraper` command to your shell.
 
-Using [pipx](https://pipx.pypa.io/):
-
 ```bash
-pipx install goodreads-user-scraper
-goodreads-user-scraper --user_id <your id> --output_dir goodreads-data
-```
-
-Or with [uv](https://docs.astral.sh/uv/):
-
-```bash
-uv tool install goodreads-user-scraper
-goodreads-user-scraper --user_id <your id> --output_dir goodreads-data
+pipx install goodreads-user-scraper      # or: uv tool install goodreads-user-scraper
+goodreads-user-scraper --user_id <your id>
 ```
 
 ### Run once without installing
 
 Best for one-off use. Downloads and runs the CLI in a temporary environment: no install step, no `$PATH` changes.
 
-Using `pipx`:
-
 ```bash
-pipx run goodreads-user-scraper --user_id <your id> --output_dir goodreads-data
-```
-
-Or with `uvx` (ships with `uv`):
-
-```bash
-uvx goodreads-user-scraper --user_id <your id> --output_dir goodreads-data
+pipx run goodreads-user-scraper --user_id <your id>
+# or: uvx goodreads-user-scraper --user_id <your id>
 ```
 
 ## Arguments
@@ -82,21 +68,6 @@ uvx goodreads-user-scraper --user_id <your id> --output_dir goodreads-data
 - **Required**: No
 - **Default**: `goodreads-data`
 
-### `--skip_user_info`
-
-- **Description**: If passed, skip scraping user information.
-- **Required**: No
-
-### `--skip_shelves`
-
-- **Description**: If passed, skip scraping shelves.
-- **Required**: No
-
-### `--skip_authors`
-
-- **Description**: If passed, skip scraping authors.
-- **Required**: No
-
 ### `--cookie`
 
 - **Description**: Your Goodreads session cookie (the full `Cookie:` request-header value). Required for shelf scraping — see [Authentication](#authentication).
@@ -105,13 +76,28 @@ uvx goodreads-user-scraper --user_id <your id> --output_dir goodreads-data
 
 ### `--cookie_file`
 
-- **Description**: Path to a text file containing your Goodreads session cookie. Used only if `--cookie` is not passed and `GOODREADS_COOKIE` is not set.
+- **Description**: Path to a text file containing your Goodreads session cookie.
 - **Required**: No
 - **Default**: None
 
+### `--skip_user_info`
+
+- **Description**: If passed, skip scraping user information.
+- **Required**: No
+
+### `--skip_shelves`
+
+- **Description**: If passed, skip scraping shelves. Books (and their authors) are scraped from your shelves, so this skips them too.
+- **Required**: No
+
+### `--skip_authors`
+
+- **Description**: If passed, skip scraping authors.
+- **Required**: No
+
 ## Authentication
 
-Shelf scraping requires authentication — Goodreads hides shelf data behind login, and the tool gathers books and authors from your shelves. So without a cookie you get a profile only; a cookie adds shelves, books, and authors, and works on your own private profile too.
+Shelf scraping requires a cookie — Goodreads hides shelf data behind login. Without one you get the profile only; with one you also get shelves, books, and authors.
 
 ### Getting your session cookie
 
@@ -136,28 +122,25 @@ If no cookie is provided, shelf scraping is skipped with a warning. Pass `--skip
 
 **Missing profile or shelf data?**
 
-- **Your own account:** pass your session cookie (see [Authentication](#authentication)). Every request is authenticated, so your profile, shelves, and books all scrape even when your profile is private — there's no need to change any Goodreads privacy settings.
-- **Another user's account:** you can only see what your logged-in account is allowed to, so their profile must be publicly viewable. Shelves still require your cookie.
+- **Your own account:** pass your session cookie (see [Authentication](#authentication)) — your profile, shelves, and books all scrape, even on a private profile.
+- **Another user's account:** what you can scrape depends on their profile privacy setting. Shelves always require your cookie (see [Authentication](#authentication)).
+  - **Anyone:** the profile scrapes even without a cookie.
+  - **Goodreads members only:** pass your cookie — any signed-in account works.
+  - **Friends only:** pass your cookie, and your account must be their friend.
 
 ## Development
 
-1. Clone the [GitHub repository](https://github.com/YashTotale/goodreads-user-scraper)
+1. Run the [install script](/scripts/install.sh)
 
-   ```shell
-   git clone https://github.com/YashTotale/goodreads-user-scraper.git
-   ```
-
-2. Run the [install script](/scripts/install.sh)
-
-   ```shell
+   ```bash
    bash scripts/install.sh
    ```
 
-3. Make changes
+2. Make changes
 
-4. Run the unit tests
+3. Run the unit tests
 
-   ```shell
+   ```bash
    pytest
    ```
 
@@ -165,9 +148,9 @@ If no cookie is provided, shelf scraping is skipped with a warning. Pass `--skip
 
    When Goodreads changes its markup, refresh the fixtures with [`scripts/capture_fixtures.py`](/scripts/capture_fixtures.py) (reads your cookie from `.goodreads-cookie` if present), then re-run `pytest`.
 
-5. Optionally run the live smoke test
+4. Optionally run the live smoke test
 
-   ```shell
+   ```bash
    bash scripts/test.sh
    ```
 
@@ -179,7 +162,7 @@ Publishing is automated via GitHub Actions using PyPI [Trusted Publishing](https
 
 Run the [publish script](/scripts/publish.sh) with the version bump type:
 
-```shell
+```bash
 bash scripts/publish.sh <patch|minor|major>
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Yash Totale", email = "totaleyash@gmail.com" }]
 requires-python = ">=3.13"
-keywords = ["Goodreads", "books", "reading", "Web Scraper", "CLI"]
+keywords = ["Goodreads", "books", "reading", "web scraper", "CLI"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -30,7 +30,7 @@ dynamic = ["version"]
 dev = ["black==26.5.1", "bump-my-version", "pre-commit", "pytest", "pytest-asyncio"]
 
 [project.urls]
-Homepage = "https://github.com/YashTotale/goodreads-user-scraper"
+Homepage = "https://github.com/YashTotale/goodreads-user-scraper#readme"
 "Source Code" = "https://github.com/YashTotale/goodreads-user-scraper"
 "Bug Tracker" = "https://github.com/YashTotale/goodreads-user-scraper/issues"
 "Release Notes" = "https://github.com/YashTotale/goodreads-user-scraper/releases"

--- a/scraper/__main__.py
+++ b/scraper/__main__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.text import Text
 
-from scraper import http, shelves, user
+from scraper import __version__, http, shelves, user
 
 console = Console()
 
@@ -41,13 +41,41 @@ def resolve_cookie(args: argparse.Namespace) -> str | None:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--user_id", type=str, required=True)
-    parser.add_argument("--output_dir", type=Path, default=Path("goodreads-data"))
-    parser.add_argument("--skip_user_info", action="store_true")
-    parser.add_argument("--skip_shelves", action="store_true")
-    parser.add_argument("--skip_authors", action="store_true")
-    parser.add_argument("--cookie", type=str, default=None)
-    parser.add_argument("--cookie_file", type=str, default=None)
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    parser.add_argument(
+        "--user_id", type=str, required=True, help="Goodreads user id to scrape"
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=Path,
+        default=Path("goodreads-data"),
+        help="output directory for scraped data (default: goodreads-data)",
+    )
+    parser.add_argument(
+        "--cookie",
+        type=str,
+        default=None,
+        help="Goodreads session cookie; required for shelf scraping",
+    )
+    parser.add_argument(
+        "--cookie_file",
+        type=str,
+        default=None,
+        help="path to a file containing the session cookie",
+    )
+    parser.add_argument(
+        "--skip_user_info", action="store_true", help="skip scraping user info"
+    )
+    parser.add_argument(
+        "--skip_shelves",
+        action="store_true",
+        help="skip scraping shelves and their books",
+    )
+    parser.add_argument(
+        "--skip_authors", action="store_true", help="skip scraping authors"
+    )
 
     args = parser.parse_args()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 
 import pytest
 
-from scraper import __main__
+from scraper import __main__, __version__
 
 # resolve_cookie precedence: --cookie > GOODREADS_COOKIE env > --cookie_file.
 
@@ -49,6 +49,14 @@ def _run_cli(monkeypatch, *argv):
     monkeypatch.delenv("GOODREADS_COOKIE", raising=False)
     monkeypatch.setattr(sys, "argv", ["scraper", *argv])
     __main__.main()
+
+
+def test_cli_version_prints_and_exits(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["goodreads-user-scraper", "--version"])
+    with pytest.raises(SystemExit) as exc:
+        __main__.main()
+    assert exc.value.code == 0
+    assert capsys.readouterr().out.strip().endswith(__version__)
 
 
 def test_cli_writes_user_json(tmp_path, monkeypatch, mock_get_soup):


### PR DESCRIPTION
Adds a `--version` flag and per-argument `--help` text, and reorders the CLI arguments by intent (target/destination, auth, skips). Trims and corrects the README: condenses Usage to one block per install mode, fixes the "another user" privacy tiers, documents the `--skip_shelves` → books/authors cascade, removes the redundant clone step, and standardizes code fences. Tidies PyPI metadata so the Homepage deep-links to the README and a keyword is lowercased. Adds a test covering `--version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)