### PR TITLE
Parameterize scripts/test.sh user_id via GOODREADS_USER_ID

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,3 +26,5 @@ jobs:
         env:
           GOODREADS_COOKIE: ${{ secrets.GOODREADS_COOKIE }}
       - run: bash scripts/test.sh
+        env:
+          GOODREADS_USER_ID: ${{ vars.GOODREADS_USER_ID }}

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ If no cookie is provided, shelf scraping is skipped with a warning. Pass `--skip
    bash scripts/test.sh
    ```
 
-   This scrapes the real Goodreads site end to end. To include shelf scraping, save your Goodreads cookie to a gitignored `.goodreads-cookie` file in the repo root — the test script picks it up automatically. CI runs this monthly (see [`integration.yml`](/.github/workflows/integration.yml)) to catch Goodreads markup changes.
+   This scrapes the real Goodreads site end to end against a sample profile; set `GOODREADS_USER_ID` to scrape your own instead. To include shelf scraping, save your Goodreads cookie to a gitignored `.goodreads-cookie` file in the repo root — the test script picks it up automatically. CI runs this monthly (see [`integration.yml`](/.github/workflows/integration.yml)) to catch Goodreads markup changes.
 
 ## Publishing
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,6 +9,7 @@ if [ -f .venv/bin/activate ]; then
 fi
 
 PYTHON="${PYTHON:-python3}"
+USER_ID="${GOODREADS_USER_ID:-54739262}"
 
 if ! command -v "$PYTHON" >/dev/null 2>&1; then
   echo "Error: $PYTHON not found."
@@ -17,7 +18,7 @@ if ! command -v "$PYTHON" >/dev/null 2>&1; then
 fi
 
 if [ -f .goodreads-cookie ]; then
-  "$PYTHON" -m scraper --user_id 54739262 --output_dir goodreads-data --cookie_file .goodreads-cookie
+  "$PYTHON" -m scraper --user_id "$USER_ID" --output_dir goodreads-data --cookie_file .goodreads-cookie
 else
-  "$PYTHON" -m scraper --user_id 54739262 --output_dir goodreads-data
+  "$PYTHON" -m scraper --user_id "$USER_ID" --output_dir goodreads-data
 fi


### PR DESCRIPTION
Reads the smoke-test `user_id` from a `GOODREADS_USER_ID` env var (defaulting to the existing `54739262`), so contributors can run `scripts/test.sh` against their own Goodreads profile without editing the script. The integration workflow now plumbs the value through from a `vars.GOODREADS_USER_ID` repo variable, falling back to the default when unset so CI behaves unchanged. The README's smoke-test step documents the override.

Closes #14