### PR TITLE
Switch ⚠️ warning emoji to 🟡 for consistent Nerd Font rendering

### DIFF
--- a/scraper/__main__.py
+++ b/scraper/__main__.py
@@ -82,7 +82,7 @@ def main():
 
     if args.skip_user_info and args.skip_shelves:
         console.print(
-            "⚠️  Nothing to do: --skip_user_info and --skip_shelves are both set."
+            "🟡  Nothing to do: --skip_user_info and --skip_shelves are both set."
         )
         return
 

--- a/scraper/shelves.py
+++ b/scraper/shelves.py
@@ -121,7 +121,7 @@ async def process_book(book_id, info, args, output_dir) -> bool:
             json.dump(book, file, indent=2)
         return False
     except Exception as e:
-        console.print(f"⚠️  Skipped {book_id}: {e}")
+        console.print(f"🟡  Skipped {book_id}: {e}")
         return isinstance(e, http.FetchError)
 
 
@@ -131,7 +131,7 @@ async def get_all_shelves(args: Namespace, profile=None) -> int:
 
     if not http.has_cookie():
         print(
-            "⚠️  Skipping shelves: Goodreads requires login to view shelf data.\n"
+            "🟡  Skipping shelves: Goodreads requires login to view shelf data.\n"
             "   To scrape shelves, provide your Goodreads session cookie via one of:\n"
             '     --cookie "<cookie string>"\n'
             "     GOODREADS_COOKIE=<cookie string>   (environment variable)\n"


### PR DESCRIPTION
Nerd Fonts ship their own glyph at U+26A0 and ignore the FE0F emoji-presentation selector, so `⚠️` renders as a thin monochrome triangle — visibly inconsistent with the full-color emoji the CLI prints (`👤 📁 📚 📖 ❌`). This swaps `⚠️` for `🟡` (U+1F7E1) at all three warning sites, which keeps the amber "caution" feel, renders as a proper color emoji in Nerd Fonts, and stays distinct from the red `❌` error marker.

All 91 tests pass. Per the issue, the demo GIFs still need re-rendering (`bash scripts/render_demos.sh`) after the next release.

Closes #29