### PR TITLE
Raise AuthError on invalid cookie instead of sys.exit in async code

### DIFF
--- a/scraper/__main__.py
+++ b/scraper/__main__.py
@@ -92,7 +92,7 @@ def main() -> None:
 
     try:
         fetch_failures = asyncio.run(scrape_user(args, cookie))
-    except http.FetchError as e:
+    except (http.AuthError, http.FetchError) as e:
         sys.exit(f"❌ {e}")
 
     if fetch_failures:

--- a/scraper/http.py
+++ b/scraper/http.py
@@ -3,7 +3,6 @@
 import asyncio
 import email.utils
 import random
-import sys
 from datetime import datetime, timezone
 
 import aiohttp
@@ -56,6 +55,14 @@ def _detect_auth_failure(soup: BeautifulSoup, body: str) -> bool:
     if "wrong with your Goodreads cookie" in body:
         return True
     return False
+
+
+class AuthError(Exception):
+    # Plain Exception, not sys.exit: a SystemExit escaping a gathered task prints a traceback.
+    def __init__(self) -> None:
+        super().__init__(
+            "Cookie appears invalid or expired. Re-grab the Cookie header value from your browser DevTools and try again."
+        )
 
 
 class FetchError(Exception):
@@ -119,7 +126,5 @@ async def get_soup(url: str) -> BeautifulSoup:
     html = await get_html(url)
     soup = BeautifulSoup(html, "html.parser")
     if _has_cookie and _detect_auth_failure(soup, html):
-        sys.exit(
-            "❌ Cookie appears invalid or expired. Re-grab the Cookie header value from your browser DevTools and try again."
-        )
+        raise AuthError()
     return soup

--- a/scraper/shelves.py
+++ b/scraper/shelves.py
@@ -133,6 +133,8 @@ async def process_book(
         with open(file_path, "w") as file:
             json.dump(book, file, indent=2)
         return False
+    except http.AuthError:
+        raise  # a bad cookie dooms the whole run, not just this book
     except Exception as e:
         console.print(f"🟡  Skipped {book_id}: {e}")
         return isinstance(e, http.FetchError)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -183,8 +183,7 @@ async def test_get_html_honors_and_caps_retry_after(fake_http):
     assert sleeps == [http.MAX_BACKOFF]
 
 
-# get_soup auth detection — AuthError must be a plain Exception so it surfaces
-# cleanly through asyncio.gather instead of tearing the loop down like SystemExit.
+# AuthError is a plain Exception so it surfaces through gather rather than killing the loop like SystemExit.
 
 SIGN_IN_PAGE = '<div id="third_party_sign_in"></div>'
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -181,3 +181,29 @@ async def test_get_html_honors_and_caps_retry_after(fake_http):
 
     await http.get_html("https://x")
     assert sleeps == [http.MAX_BACKOFF]
+
+
+# get_soup auth detection — AuthError must be a plain Exception so it surfaces
+# cleanly through asyncio.gather instead of tearing the loop down like SystemExit.
+
+SIGN_IN_PAGE = '<div id="third_party_sign_in"></div>'
+
+
+def test_autherror_is_a_plain_exception():
+    assert issubclass(http.AuthError, Exception)
+
+
+async def test_get_soup_raises_autherror_on_auth_failure(fake_http, monkeypatch):
+    fake_http([_FakeResponse(200, body=SIGN_IN_PAGE)])
+    monkeypatch.setattr(http, "_has_cookie", True)
+
+    with pytest.raises(http.AuthError):
+        await http.get_soup("https://x")
+
+
+async def test_get_soup_skips_auth_check_without_cookie(fake_http, monkeypatch):
+    fake_http([_FakeResponse(200, body=SIGN_IN_PAGE)])
+    monkeypatch.setattr(http, "_has_cookie", False)
+
+    soup = await http.get_soup("https://x")
+    assert soup.select_one("div#third_party_sign_in") is not None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -122,6 +122,34 @@ def test_cli_full_run_writes_user_and_books(tmp_path, monkeypatch, mock_get_soup
     assert book["shelves"] == ["read"]
 
 
+def test_cli_invalid_cookie_exits_cleanly(tmp_path, monkeypatch, soup):
+    # An expired cookie makes shelf pages return Goodreads' sign-in wall, which
+    # get_soup flags as AuthError from inside the concurrent shelf fetches. main()
+    # must surface a clean ❌ message, not let it escape as a traceback.
+    profile = soup("profile.html")
+
+    async def fake(url):
+        if "review/list" in url:
+            raise http.AuthError()
+        return profile
+
+    monkeypatch.setattr("scraper.http.get_soup", fake)
+
+    with pytest.raises(SystemExit) as exc:
+        _run_cli(
+            monkeypatch,
+            "--user_id",
+            "54739262",
+            "--output_dir",
+            str(tmp_path),
+            "--cookie",
+            "fake-cookie",
+            "--skip_authors",
+        )
+
+    assert "Cookie appears invalid or expired" in str(exc.value.code)
+
+
 def test_cli_finishes_then_fails_when_book_fetches_are_exhausted(
     tmp_path, monkeypatch, mock_get_soup, capsys
 ):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -123,9 +123,7 @@ def test_cli_full_run_writes_user_and_books(tmp_path, monkeypatch, mock_get_soup
 
 
 def test_cli_invalid_cookie_exits_cleanly(tmp_path, monkeypatch, soup):
-    # An expired cookie makes shelf pages return Goodreads' sign-in wall, which
-    # get_soup flags as AuthError from inside the concurrent shelf fetches. main()
-    # must surface a clean ❌ message, not let it escape as a traceback.
+    # An expired cookie returns the sign-in wall during shelf fetches; main() must exit with a clean ❌, not a traceback.
     profile = soup("profile.html")
 
     async def fake(url):

--- a/tests/test_shelves.py
+++ b/tests/test_shelves.py
@@ -166,6 +166,17 @@ async def test_process_book_skips_other_errors(tmp_path, monkeypatch):
     assert not (tmp_path / "x.json").exists()
 
 
+async def test_process_book_does_not_swallow_auth_error(tmp_path, monkeypatch):
+    # A mid-run cookie expiry surfaces as AuthError; it must abort the run, not be swallowed like a parse error.
+    async def boom(book_id, args):
+        raise http.AuthError()
+
+    monkeypatch.setattr("scraper.books.scrape_book", boom)
+    info = {"shelves": ["read"], "rating": None, "dates_read": []}
+    with pytest.raises(http.AuthError):
+        await shelves.process_book("x", info, Namespace(skip_authors=True), tmp_path)
+
+
 # get_all_shelves orchestrator
 
 


### PR DESCRIPTION
## Summary
`get_soup` called `sys.exit()` on an auth-failure page, raising `SystemExit` inside the `asyncio.gather`'d shelf fetches — which asyncio surfaces as a full traceback instead of the intended clean message. It now raises a plain `AuthError`, caught in `main()` outside `asyncio.run` and printed as just the `❌ Cookie appears invalid or expired…` line (exit 1). Fixes #31.

## Test plan
Added unit tests (`get_soup` raises `AuthError` on an auth page, skips the check without a cookie) plus an integration test reproducing the bug through the concurrent shelf gather. Full suite (99 tests), black, and mypy all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)