### PR TITLE
feat: add exclusive shelf detection to book output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ goodreads-data/
     └── …
 ```
 
-Each `books/*.json` looks like this — your `rating`, `dates_read`, and `shelves` come from your library; the author is nested:
+Each `books/*.json` looks like this — your `rating`, `dates_read`, `shelves`, and `exclusive_shelf` (the one status shelf, e.g. `read`, or `null`) come from your library; the author is nested:
 
 ```json
 {
@@ -91,7 +91,8 @@ Each `books/*.json` looks like this — your `rating`, `dates_read`, and `shelve
   },
   "rating": 5,
   "dates_read": ["May 03, 2020"],
-  "shelves": ["read", "2020", "2020s-favorites"]
+  "shelves": ["read", "2020", "2020s-favorites"],
+  "exclusive_shelf": "read"
 }
 ```
 

--- a/scraper/shelves.py
+++ b/scraper/shelves.py
@@ -23,6 +23,18 @@ from scraper.parse import find_tag
 PER_PAGE = 100
 console = Console()
 
+# Shelf print pages init a ShelfChooser JS object naming the exclusive shelves.
+_EXCLUSIVE_RE = re.compile(r"exclusive:\s*\[([^\]]*)\]")
+
+
+def get_exclusive_shelves(soup: BeautifulSoup) -> set[str]:
+    """The user's exclusive shelves (read, to-read, …), from any shelf page."""
+    for script in soup.find_all("script"):
+        match = _EXCLUSIVE_RE.search(script.get_text())
+        if match:
+            return set(re.findall(r'"([^"]+)"', match.group(1)))
+    return set()
+
 
 def make_progress() -> Progress:
     return Progress(
@@ -75,21 +87,25 @@ def get_dates_read(book_row: Tag) -> list[str]:
     return date_arr
 
 
-async def collect_shelf_rows(user_id: str, shelf: str) -> list[Tag]:
+async def collect_shelf_rows(user_id: str, shelf: str) -> tuple[list[Tag], set[str]]:
     rows: list[Tag] = []
+    exclusive: set[str] = set()
     page = 1
     while True:
         soup = await fetch_shelf_page(user_id, shelf, page)
+        if page == 1:
+            exclusive = get_exclusive_shelves(soup)
         if soup.find("div", {"class": "greyText nocontent stacked"}):
             break
         body = find_tag(soup, "tbody", {"id": "booksBody"})
         rows.extend(body.find_all("tr", recursive=False))
         page += 1
-    return rows
+    return rows, exclusive
 
 
 def _dedupe_books(
     shelf_rows: list[tuple[str, list[Tag]]],
+    exclusive_shelves: set[str],
 ) -> dict[str, dict[str, Any]]:
     books_by_id: dict[str, dict[str, Any]] = {}
     for shelf, page_rows in shelf_rows:
@@ -100,6 +116,7 @@ def _dedupe_books(
                 if entry is None:
                     entry = {
                         "shelves": [],
+                        "exclusive_shelf": None,
                         "rating": get_rating(row),
                         "dates_read": get_dates_read(row),
                     }
@@ -108,6 +125,8 @@ def _dedupe_books(
                 continue  # skip a malformed row
             if shelf not in entry["shelves"]:
                 entry["shelves"].append(shelf)
+            if shelf in exclusive_shelves:
+                entry["exclusive_shelf"] = shelf  # at most one per book
     return books_by_id
 
 
@@ -129,6 +148,7 @@ async def process_book(
             book["rating"] = info["rating"]
             book["dates_read"] = info["dates_read"]
             book["shelves"] = info["shelves"]
+            book["exclusive_shelf"] = info["exclusive_shelf"]
 
         with open(file_path, "w") as file:
             json.dump(book, file, indent=2)
@@ -175,15 +195,17 @@ async def get_all_shelves(args: Namespace, profile: BeautifulSoup | None = None)
     with make_progress() as progress:
         task = progress.add_task("Finding shelves", total=len(shelf_names))
 
-        async def collect(shelf: str) -> tuple[str, list[Tag]]:
-            rows = await collect_shelf_rows(user_id, shelf)
+        async def collect(shelf: str) -> tuple[str, list[Tag], set[str]]:
+            rows, exclusive = await collect_shelf_rows(user_id, shelf)
             progress.advance(task)
-            return shelf, rows
+            return shelf, rows, exclusive
 
         per_shelf = await asyncio.gather(*(collect(shelf) for shelf in shelf_names))
     console.print(f"📚  {len(shelf_names)} shelves")
 
-    books_by_id = _dedupe_books(per_shelf)
+    # The exclusive set is user-global, so any shelf's copy will do.
+    exclusive_shelves = next((ex for *_, ex in per_shelf if ex), set())
+    books_by_id = _dedupe_books([(s, r) for s, r, _ in per_shelf], exclusive_shelves)
 
     with make_progress() as progress:
         task = progress.add_task("Scraping books", total=len(books_by_id))

--- a/tests/test_shelves.py
+++ b/tests/test_shelves.py
@@ -37,6 +37,23 @@ def test_get_dates_read_when_missing(soup):
     assert shelves.get_dates_read(rows(soup, "shelf_to_read.html")[0]) == []
 
 
+# get_exclusive_shelves
+
+
+def test_get_exclusive_shelves(soup):
+    assert shelves.get_exclusive_shelves(soup("shelf_read.html")) == {
+        "to-read",
+        "currently-reading",
+        "read",
+        "did-not-finish",
+    }
+
+
+def test_get_exclusive_shelves_absent_returns_empty(soup):
+    # The profile page carries no ShelfChooser, so there is no exclusive list.
+    assert shelves.get_exclusive_shelves(soup("profile.html")) == set()
+
+
 # fetch_shelf_page
 
 
@@ -66,8 +83,9 @@ async def test_collect_shelf_rows_paginates_until_empty(mock_get_soup):
             "&page=3&": "shelf_empty.html",
         }
     )
-    collected = await shelves.collect_shelf_rows("54739262", "read")
-    assert len(collected) == 40  # 30 (page 1) + 10 (page 2), then page 3 terminates
+    rows, exclusive = await shelves.collect_shelf_rows("54739262", "read")
+    assert len(rows) == 40  # 30 (page 1) + 10 (page 2), then page 3 terminates
+    assert exclusive == {"to-read", "currently-reading", "read", "did-not-finish"}
 
 
 # _dedupe_books
@@ -75,18 +93,25 @@ async def test_collect_shelf_rows_paginates_until_empty(mock_get_soup):
 
 def test_dedupe_merges_book_across_shelves(soup):
     row = rows(soup, "shelf_read.html")[0]
-    books = shelves._dedupe_books([("read", [row]), ("favorites", [row])])
+    books = shelves._dedupe_books([("read", [row]), ("favorites", [row])], {"read"})
     assert list(books) == [READ_BOOK_ID]
     entry = books[READ_BOOK_ID]
     assert entry["shelves"] == ["read", "favorites"]
+    assert entry["exclusive_shelf"] == "read"  # the one exclusive shelf it sits on
     assert entry["rating"] == 4
     assert entry["dates_read"] == ["May 19, 2026"]
+
+
+def test_dedupe_without_exclusive_shelf(soup):
+    row = rows(soup, "shelf_read.html")[0]
+    books = shelves._dedupe_books([("favorites", [row])], {"read", "to-read"})
+    assert books[READ_BOOK_ID]["exclusive_shelf"] is None
 
 
 def test_dedupe_skips_unparseable_row(soup):
     good = rows(soup, "shelf_read.html")[0]
     bad = BeautifulSoup("<tr></tr>", "html.parser").find("tr")
-    books = shelves._dedupe_books([("read", [good, bad])])
+    books = shelves._dedupe_books([("read", [good, bad])], {"read"})
     assert list(books) == [READ_BOOK_ID]  # malformed row dropped
 
 
@@ -98,7 +123,7 @@ def test_dedupe_skips_row_missing_rating_cell(soup):
         '<a href="/book/show/123-x">x</a></div></td></tr>',
         "html.parser",
     ).find("tr")
-    books = shelves._dedupe_books([("read", [good, partial])])
+    books = shelves._dedupe_books([("read", [good, partial])], {"read"})
     assert list(books) == [READ_BOOK_ID]
 
 
@@ -107,13 +132,19 @@ def test_dedupe_skips_row_missing_rating_cell(soup):
 
 async def test_process_book_scrapes_new(tmp_path, mock_get_soup):
     mock_get_soup({"book/show": "book.html"})
-    info = {"shelves": ["read"], "rating": 4, "dates_read": ["May 19, 2026"]}
+    info = {
+        "shelves": ["read"],
+        "exclusive_shelf": "read",
+        "rating": 4,
+        "dates_read": ["May 19, 2026"],
+    }
     await shelves.process_book(
         READ_BOOK_ID, info, Namespace(skip_authors=True), tmp_path
     )
 
     data = json.loads((tmp_path / f"{READ_BOOK_ID}.json").read_text())
     assert data["shelves"] == ["read"]
+    assert data["exclusive_shelf"] == "read"
     assert data["rating"] == 4
     assert data["dates_read"] == ["May 19, 2026"]
     assert data["book_title"] == "Dungeon Crawler Carl"
@@ -127,13 +158,19 @@ async def test_process_book_merges_into_existing_without_rescrape(
     fetched = []
     monkeypatch.setattr("scraper.http.get_soup", lambda url: fetched.append(url))
 
-    info = {"shelves": ["read", "favorites"], "rating": 4, "dates_read": []}
+    info = {
+        "shelves": ["read", "favorites"],
+        "exclusive_shelf": "read",
+        "rating": 4,
+        "dates_read": [],
+    }
     await shelves.process_book(
         READ_BOOK_ID, info, Namespace(skip_authors=True), tmp_path
     )
 
     data = json.loads(book_file.read_text())
     assert data["shelves"] == ["read", "favorites"]
+    assert "exclusive_shelf" not in data  # frozen, not backfilled
     assert data["book_title"] == "SEEDED"  # not re-scraped
     assert fetched == []
 
@@ -239,3 +276,4 @@ async def test_get_all_shelves_dedupes_and_scrapes(
     assert {p.stem for p in books_dir.glob("*.json")} == expected
     read_book = json.loads((books_dir / f"{READ_BOOK_ID}.json").read_text())
     assert "read" in read_book["shelves"]
+    assert read_book["exclusive_shelf"] == "read"


### PR DESCRIPTION
Resolves #41 by adding an `exclusive_shelf` field to each book's JSON — the one status shelf it sits on (`read`, `to-read`, etc.) or `null` — so consumers know a book's status without guessing from the shelf list. The exclusive set is read once per run from the `ShelfChooser` JS on the shelf print page (the markup the issue proposed, `ul.shelves`/`li.exclusive`, no longer exists on Goodreads), then matched against each book's shelves during dedup. Like `rating` and `dates_read`, the field is written on first scrape and not refreshed on re-runs. The README book schema is updated to document the new field, and tests cover the new parser, dedup tagging, and the frozen-on-re-run behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Books now track exclusive shelf membership with a new `exclusive_shelf` field that indicates which exclusive shelf a book belongs to.

* **Documentation**
  * Updated book output documentation to include the new `exclusive_shelf` field in the list of properties exported in book JSON records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->