### PR TITLE
Handle Goodreads tag shelf links

### DIFF
--- a/scraper/shelves.py
+++ b/scraper/shelves.py
@@ -188,7 +188,7 @@ async def get_all_shelves(args: Namespace, profile: BeautifulSoup | None = None)
     for link in shelf_links:
         href = link.get("href")
         assert isinstance(href, str)
-        match = re.search(r"\?shelf=([^&]+)", href)
+        match = re.search(r"[?&](?:shelf|tag)=([^&]+)", href)
         assert match is not None
         shelf_names.append(match.group(1))
 

--- a/tests/fixtures/profile.html
+++ b/tests/fixtures/profile.html
@@ -423,7 +423,7 @@ Sign in with Facebook
 </a>            <br>
         </div>
         <div class="shelfContainer">
-            <a class="actionLinkLite userShowPageShelfListItem" href="/review/list/54739262?shelf=2019">
+            <a class="actionLinkLite userShowPageShelfListItem" href="/review/list/54739262?tag=2019">
               2019&lrm;
               (35)
 </a>            <br>


### PR DESCRIPTION
Goodreads now uses `tag` parameters for custom shelf links while retaining `shelf` for built-in shelves, causing the live integration workflow to fail during profile parsing.

This updates shelf-name extraction to accept both current link formats and refreshes the profile fixture with the authenticated markup.

Validated with 103 unit tests, Black, mypy, `git diff --check`, and authenticated live shelf parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shelf link parsing to support URLs using either the `shelf` or `tag` query parameter.
  * Ensured bookshelf links using tag-based URLs are recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->